### PR TITLE
INS-4051 Bring SRP-Style up to version 1.22.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 Gemfile.lock
 spec/examples.txt

--- a/lib/rubocop/cop/layout/space_before_comma_plus.rb
+++ b/lib/rubocop/cop/layout/space_before_comma_plus.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubocop/cop/mixin/kwarg_node"
 require_relative "../mixin/space_before_punctuation"
 
@@ -41,7 +43,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include KwargNode
 
-        MSG_SPACE_AFTER_COLON = "No space found after colon.".freeze
+        MSG_SPACE_AFTER_COLON = "No space found after colon."
 
         def kind(token)
           "comma" if token.comma?
@@ -92,3 +94,4 @@ module RuboCop
     end
   end
 end
+

--- a/lib/rubocop/cop/layout/space_inside_parens_plus.rb
+++ b/lib/rubocop/cop/layout/space_inside_parens_plus.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rubocop/cop/mixin/kwarg_node"
 
 module RuboCop
@@ -67,7 +69,7 @@ module RuboCop
         end
 
         def autocorrect(corrector, range)
-          if style == :space || (style == :space_after_colon && @kwarg)
+          if style == :space || style == :space_after_colon && @kwarg
             corrector.insert_before(range, " ")
           else
             corrector.remove(range)
@@ -112,7 +114,7 @@ module RuboCop
         def range_for(token1, token2)
           if style == :space
             space_range_for(token1, token2)
-          elsif style == :no_space || (style == :space_after_colon && !@kwarg)
+          elsif style == :no_space || style == :space_after_colon && !@kwarg
             range_between(token1.end_pos, token2.begin_pos)
           else # :space_after_colon && @kwarg
             range_between(token2.begin_pos, token2.end_pos)
@@ -142,3 +144,4 @@ module RuboCop
     end
   end
 end
+

--- a/lib/rubocop/cop/mixin/kwarg_node.rb
+++ b/lib/rubocop/cop/mixin/kwarg_node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     # Common methods for checking if a token is a kwarg.
@@ -16,3 +18,4 @@ module RuboCop
     end
   end
 end
+

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RuboCop
   module Cop
     # Common functionality for cops checking for space before
@@ -43,3 +45,4 @@ module RuboCop
     end
   end
 end
+

--- a/lib/srp/style/version.rb
+++ b/lib/srp/style/version.rb
@@ -1,5 +1,5 @@
 module SRP
   module Style
-    VERSION = "0.87.1".freeze
+    VERSION = "1.22.1".freeze
   end
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - '**/*.rb'
 
   DisplayCopNames: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
 
 #===============
 # Layout

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - '**/*.rb'
 
   DisplayCopNames: true
+  TargetRubyVersion: 2.6
 
 #===============
 # Layout

--- a/spec/rubocop/cop/layout/space_before_comma_plus_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comma_plus_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "rubocop/cop/layout/space_before_comma_plus"
 
@@ -8,7 +10,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeCommaPlus, :config do
   let(:enforced_style) { "no_space" }
 
   it "registers an offense and corrects block argument " \
-     "with space before comma" do
+    "with space before comma" do
     expect_offense(<<~RUBY)
       each { |s , t| }
                ^ Space found before comma.
@@ -31,7 +33,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeCommaPlus, :config do
   end
 
   it "registers an offense and corrects method call arg " \
-     "with space before comma" do
+    "with space before comma" do
     expect_offense(<<~RUBY)
       a(1 , 2)
          ^ Space found before comma.
@@ -119,3 +121,4 @@ RSpec.describe RuboCop::Cop::Layout::SpaceBeforeCommaPlus, :config do
     RUBY
   end
 end
+

--- a/spec/rubocop/cop/layout/space_inside_parens_plus_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_plus_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "rubocop/cop/layout/space_inside_parens_plus"
 
@@ -51,7 +53,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParensPlus, :config do
     end
 
     it "registers an offense for spaces inside parens " \
-       "following a keyword argument with a value" do
+      "following a keyword argument with a value" do
       expect_offense(<<~RUBY)
         def a(foo: nil ); end
                       ^ Space inside parentheses detected.
@@ -124,7 +126,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParensPlus, :config do
     end
 
     it "registers an offense for no spaces inside parens " \
-       "following a keyword argument" do
+      "following a keyword argument" do
       expect_offense(<<~RUBY)
         def a(foo:); end
               ^ No space inside parentheses detected.
@@ -141,7 +143,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParensPlus, :config do
     end
 
     it "registers an offense for spaces inside parens " \
-       "following a keyword argument with a value" do
+      "following a keyword argument with a value" do
       expect_offense(<<~RUBY)
         def a(foo: nil ); end
               ^ No space inside parentheses detected.
@@ -203,7 +205,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParensPlus, :config do
     end
 
     it "registers an offense for spaces inside parens " \
-       "following a keyword argument with a value" do
+      "following a keyword argument with a value" do
       expect_offense(<<~RUBY)
         def a(foo: nil ); end
                       ^ Space inside parentheses detected.
@@ -218,7 +220,7 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParensPlus, :config do
     end
 
     it "registers an offense for no spaces inside parens " \
-       "following a keyword argument" do
+      "following a keyword argument" do
       expect_offense(<<~RUBY)
         def a(foo:); end
                   ^ No space after colon inside parentheses.
@@ -230,3 +232,4 @@ RSpec.describe RuboCop::Cop::Layout::SpaceInsideParensPlus, :config do
     end
   end
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Disable colors in specs
 require "rainbow"
 Rainbow.enabled = false
@@ -17,7 +19,7 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  unless defined?(::TestQueue)
+  unless defined?(TestQueue)
     # See. https://github.com/tmm1/test-queue/issues/60#issuecomment-281948929
     config.filter_run :focus
     config.run_all_when_everything_filtered = true
@@ -40,4 +42,11 @@ RSpec.configure do |config|
     mocks.syntax = :expect # Disable `should_receive` and `stub`
     mocks.verify_partial_doubles = true
   end
+
+  # rubocop:disable Style/IfUnlessModifier
+  if %w[ruby-head-ascii_spec ruby-head-spec].include?(ENV["CIRCLE_STAGE"])
+    config.filter_run_excluding(broken_on: :ruby_head)
+  end
+  # rubocop:enable Style/IfUnlessModifier
 end
+

--- a/srp-style.gemspec
+++ b/srp-style.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Style rules for Ruby"
   spec.homepage      = "https://github.com/srpatx/srp-style"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.6")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/srp-style.gemspec
+++ b/srp-style.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Style rules for Ruby"
   spec.homepage      = "https://github.com/srpatx/srp-style"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Update srp-style to version 1.22.1 and latest groundwork-style dependencies

- Update version from 0.87.1 to 1.22.1
- Update all RuboCop dependencies to latest compatible versions
- Update custom cops and specs to latest versions
- Add vendor/ to .gitignore to exclude bundle installation
- Maintain compatibility with Ruby 3.0+